### PR TITLE
Fix missing notifications secret, metadata.name error and techdocs placeholders

### DIFF
--- a/apptemplates/simplenodeservice-content/backstagetemplates/catalog-info.yaml
+++ b/apptemplates/simplenodeservice-content/backstagetemplates/catalog-info.yaml
@@ -34,7 +34,7 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Group
 metadata:
-  name: ${{ values.teamIdentifier }}
+  name: "${{ values.teamIdentifier }}"
   description: Group for application team ${{ values.teamIdentifier }}
 spec:
   type: business-unit

--- a/cluster_installer.py
+++ b/cluster_installer.py
@@ -196,6 +196,11 @@ output = run_command(["kubectl", "apply", "-n", "argocd", "-f", "gitops/manifest
 output = run_command(["kubectl", "apply", "-n", "argocd", "-f", "gitops/manifests/platform/argoconfig/argocd-no-tls.yml"])
 output = run_command(["kubectl", "apply", "-n", "argocd", "-f", "gitops/manifests/platform/argoconfig/argocd-nodeport.yml"])
 
+# Create argocd-notifications-secret
+output = run_command(["kubectl", "-n", "argocd", "create", "secret", "generic", "argocd-notifications-secret", f"--from-literal=dynatrace-url={DT_TENANT_LIVE}", f"--from-literal=dynatrace-token={DT_ALL_INGEST_TOKEN}"])
+output = run_command(["kubectl", "-n", "argocd", "scale", "deploy/argocd-notifications-controller", "--replicas=0"])
+output = run_command(["kubectl", "-n", "argocd", "scale", "deploy/argocd-notifications-controller", "--replicas=1"])
+
 # Restart argo server
 output = run_command(["kubectl", "-n", "argocd", "scale", "deployment/argocd-server", "--replicas", "0"])
 output = run_command(["kubectl", "-n", "argocd", "scale", "deployment/argocd-server", "--replicas", "1"])

--- a/cluster_installer.py
+++ b/cluster_installer.py
@@ -94,6 +94,7 @@ git_commit(target_file="-A", commit_msg="update DT_TENANT_LIVE_PLACEHOLDER", pus
 # Find and replace DT_TENANT_APPS_PLACEHOLDER with real text eg. "https://abc12345.live.apps.dynatrace.com"
 do_file_replace(pattern="./**/*.y*ml", find_string="DT_TENANT_APPS_PLACEHOLDER", replace_string=DT_TENANT_APPS, recursive=True)
 do_file_replace(pattern="./**/*.json", find_string="DT_TENANT_APPS_PLACEHOLDER", replace_string=DT_TENANT_APPS, recursive=True)
+do_file_replace(pattern="./apptemplates/docs/*.md", find_string="DT_TENANT_APPS_PLACEHOLDER", replace_string=DT_TENANT_APPS, recursive=False)
 git_commit(target_file="-A", commit_msg="update DT_TENANT_APPS_PLACEHOLDER", push=False)
 
 # Find and replace GITHUB_DOT_COM_REPO_PLACEHOLDER with real text eg. "https://github.com/yourOrg/yourRepo.git"
@@ -109,6 +110,7 @@ git_commit(target_file="-A", commit_msg="update GEOLOCATION_PLACEHOLDER", push=F
 # Find and replace GITHUB_REPOSITORY_PLACEHOLDER with real text. eg "yourOrg/yourRepo"
 do_file_replace(pattern="./**/*.y*ml", find_string="GITHUB_REPOSITORY_PLACEHOLDER", replace_string=GITHUB_ORG_SLASH_REPOSITORY, recursive=True)
 do_file_replace(pattern="./**/*.json", find_string="GITHUB_REPOSITORY_PLACEHOLDER", replace_string=GITHUB_ORG_SLASH_REPOSITORY, recursive=True)
+do_file_replace(pattern="./apptemplates/docs/*.md", find_string="GITHUB_REPOSITORY_PLACEHOLDER", replace_string=GITHUB_ORG_SLASH_REPOSITORY, recursive=False)
 git_commit(target_file="-A", commit_msg="update GITHUB_REPOSITORY_PLACEHOLDER", push=False)
 
 # Find and replace GITHUB_REPO_NAME_PLACEHOLDER with real text. eg. `yourRepo`
@@ -125,11 +127,13 @@ git_commit(target_file="-A", commit_msg="update GITHUB_ORG_NAME_PLACEHOLDER", pu
 # Find and replace CODESPACE_NAME_PLACEHOLDER with real text. eg. `fantastic-onion-123ab233`
 do_file_replace(pattern="./**/*.y*ml", find_string="CODESPACE_NAME_PLACEHOLDER", replace_string=CODESPACE_NAME, recursive=True)
 do_file_replace(pattern="./**/*.json", find_string="CODESPACE_NAME_PLACEHOLDER", replace_string=CODESPACE_NAME, recursive=True)
+do_file_replace(pattern="./apptemplates/docs/*.md", find_string="CODESPACE_NAME_PLACEHOLDER", replace_string=CODESPACE_NAME, recursive=False)
 git_commit(target_file="-A", commit_msg="update CODESPACE_NAME_PLACEHOLDER", push=False)
 
 # Find and replace ARGOCD_PORT_NUMBER_PLACEHOLDER with real text. eg. `30100`
 do_file_replace(pattern="./**/*.y*ml", find_string="ARGOCD_PORT_NUMBER_PLACEHOLDER", replace_string=f"{ARGOCD_PORT_NUMBER}", recursive=True)
 do_file_replace(pattern="./**/*.json", find_string="ARGOCD_PORT_NUMBER_PLACEHOLDER", replace_string=f"{ARGOCD_PORT_NUMBER}", recursive=True)
+do_file_replace(pattern="./apptemplates/docs/*.md", find_string="ARGOCD_PORT_NUMBER_PLACEHOLDER", replace_string=f"{ARGOCD_PORT_NUMBER}", recursive=False)
 git_commit(target_file="-A", commit_msg="update ARGOCD_PORT_NUMBER_PLACEHOLDER", push=False)
 
 # Find and replace DEMO_APP_PORT_NUMBER_PLACEHOLDER with real text. eg. `80`
@@ -145,6 +149,7 @@ git_commit(target_file="-A", commit_msg="update BACKSTAGE_PORT_NUMBER_PLACEHOLDE
 # Find and replace GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN_PLACEHOLDER with real text. eg. `.app.github.dev`
 do_file_replace(pattern="./**/*.y*ml", find_string="GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN_PLACEHOLDER", replace_string=GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN, recursive=True)
 do_file_replace(pattern="./**/*.json", find_string="GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN_PLACEHOLDER", replace_string=GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN, recursive=True)
+do_file_replace(pattern="./apptemplates/docs/*.md", find_string="GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN_PLACEHOLDER", replace_string=GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN, recursive=False)
 git_commit(target_file="-A", commit_msg="update GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN_PLACEHOLDER", push=True)
 
 


### PR DESCRIPTION
This PR:

- Quotes `metadata.name` field to prevent error
- Ensures argocd-notifications-secret is created so `CUSTOM_INFO` deployment events can be sent to DT
- Replaces placeholders in backstage techdocs template `index.md` during cluster creation