### PR TITLE
build_dt_urls: Clarify naming

### DIFF
--- a/cluster_installer.py
+++ b/cluster_installer.py
@@ -14,7 +14,7 @@ if (
     exit("Missing mandatory environment variables. Cannot proceed. Exiting.")
 
 # Build DT environment URLs
-DT_TENANT_APPS, DT_TENANT_LIVE = build_dt_urls(dt_env_name=DT_ENV_NAME, dt_env=DT_ENV)
+DT_TENANT_APPS, DT_TENANT_LIVE = build_dt_urls(dt_env_id=DT_ENV_NAME, dt_env_type=DT_ENV)
 
 # Get correct SSO URL
 DT_SSO_TOKEN_URL = get_sso_token_url(dt_env=DT_ENV)

--- a/utils.py
+++ b/utils.py
@@ -244,17 +244,19 @@ def create_dt_api_token(token_name, scopes, dt_rw_api_token, dt_tenant_live):
 
     return resp.json()['token']
 
-def build_dt_urls(dt_env, dt_env_name):
-    if dt_env.lower() == "live":
-        dt_tenant_apps = f"https://{dt_env_name}.apps.dynatrace.com"
-        dt_tenant_live = f"https://{dt_env_name}.live.dynatrace.com"
+def build_dt_urls(dt_env_id, dt_env_type):
+    if dt_env_type == "": dt_env_type == "live" # Default to live
+
+    if dt_env_type.lower() == "live":
+        dt_tenant_apps = f"https://{dt_env_id}.apps.dynatrace.com"
+        dt_tenant_live = f"https://{dt_env_id}.live.dynatrace.com"
     else:
-      dt_tenant_apps = f"https://{dt_env_name}.{dt_env}.apps.dynatrace.com"
-      dt_tenant_live = f"https://{dt_env_name}.{dt_env}.dynatrace.com"
+      dt_tenant_apps = f"https://{dt_env_id}.{dt_env_type}.apps.dynatrace.com"
+      dt_tenant_live = f"https://{dt_env_id}.{dt_env_type}.dynatrace.com"
 
     # if environment is "dev" or "sprint"
     # ".dynatracelabs.com" not ".dynatrace.com"
-    if dt_env.lower() == "dev" or dt_env.lower() == "sprint":
+    if dt_env_type.lower() == "dev" or dt_env_type.lower() == "sprint":
         dt_tenant_apps = dt_tenant_apps.replace(".dynatrace.com", ".dynatracelabs.com")
         dt_tenant_live = dt_tenant_live.replace(".dynatrace.com", ".dynatracelabs.com")
     


### PR DESCRIPTION
This PR:
* Adjusts the naming of inputs in `build_dt_urls` to more clearly reflect purpose.

* `dt_env_id` should be something like `abc12345`
* `dt_env_type` should be `live`, `sprint` etc.